### PR TITLE
Suggestions for co-log binding

### DIFF
--- a/effectful-co-log/src/Effectful/Colog.hs
+++ b/effectful-co-log/src/Effectful/Colog.hs
@@ -97,6 +97,7 @@ import Effectful.Dispatch.Static
     unEff,
     unsafeEff,
     unsafeEff_,
+    unsafeUnliftIO,
   )
 import Effectful.Monad
   ( Dispatch (Static),
@@ -189,7 +190,7 @@ fmtSimpleRichMessageDefault :: IOE :> es => Colog.RichMsg (Eff es) SimpleMsg -> 
 fmtSimpleRichMessageDefault = Colog.fmtSimpleRichMessageDefault
 
 -- | The effectful version of 'Colog.upgradeMessageAction'
-upgradeMessageAction :: IOE :> es => Colog.FieldMap (Eff es) -> LogActionEff es (Colog.RichMsg (Eff es) msg) -> LogActionEff es msg
+upgradeMessageAction :: Colog.FieldMap (Eff es) -> LogActionEff es (Colog.RichMsg (Eff es) msg) -> LogActionEff es msg
 upgradeMessageAction = Colog.upgradeMessageAction
 
 -- | The effectful version of 'Colog.logByteStringStdout'.
@@ -205,8 +206,9 @@ logByteStringHandle :: IOE :> es => Handle -> LogActionEff es ByteString
 logByteStringHandle = Colog.logByteStringHandle
 
 -- | The effectful version of 'Colog.withLogByteStringFile'.
-withLogByteStringFile :: IOE :> es => FilePath -> (LogActionEff es ByteString -> IO r) -> Eff es r
-withLogByteStringFile path action = unsafeEff_ $ Colog.withLogByteStringFile path action
+withLogByteStringFile :: IOE :> es => FilePath -> (LogActionEff es ByteString -> Eff es r) -> Eff es r
+withLogByteStringFile path action = unsafeUnliftIO $ \runInIO ->
+  Colog.withLogByteStringFile path (runInIO . action)
 
 -- | The effectful version of 'Colog.logTextStdout'.
 logTextStdout :: IOE :> es => LogActionEff es Text
@@ -221,8 +223,9 @@ logTextHandle :: IOE :> es => Handle -> LogActionEff es Text
 logTextHandle = Colog.logTextHandle
 
 -- | The effectful version of 'Colog.withLogTextFile'.
-withLogTextFile :: IOE :> es => FilePath -> (LogActionEff es Text -> IO r) -> Eff es r
-withLogTextFile path action = unsafeEff_ $ Colog.withLogTextFile path action
+withLogTextFile :: IOE :> es => FilePath -> (LogActionEff es Text -> Eff es r) -> Eff es r
+withLogTextFile path action = unsafeUnliftIO $ \runInIO ->
+  Colog.withLogTextFile path (runInIO . action)
 
 -- | The effectful version of 'Colog.simpleMessageAction'.
 simpleMessageAction :: IOE :> es => LogActionEff es Message


### PR DESCRIPTION
Hello, here are some suggestions regarding the co-log binding.
First: The binding is great and I liked the use of `forkEnv` for the `LogAction`s in particular. Nice work! :+1: 
As for the changes to the test suite: Most of them are simple code reorderings and styling issues which helped me throughout the review. Those mirror my personal taste; Feel free to incorporate those in your PR or not.

I noticed that some functions do not have a binding. For example: `Colog.Rotation.withLogRotation`, `Colog.Concurrent.withBackgroundLogger`, `Colog.Core.IO.logStringStdout`, `Colog.Core.IO.logPrint`.
Is this intentional?

In addition to the changes here I have the following ideas:
- Maybe it is good to split the bindings in `effectful-co-log-core` and `effectful-co-log` to mirror the package structure of the authors of the original package.
  This way we could provide bindings for those who are concerned about the dependency footprint of their application.
- It may be good to mirror the module hierarchy present in the original packages, e.g. `Effectful.Colog.Monad`, `Effectful.Colog.Core`, ...
  This makes it a bit easier to track for which functions/types we provide bindings to.
Both ideas could be implemented in a separate PR so we can merge yours quickly.
@ambroslins What do you think?