### PR TITLE
Fix concurrency issues

### DIFF
--- a/effectful-co-log/src/Effectful/Colog/Concurrent.hs
+++ b/effectful-co-log/src/Effectful/Colog/Concurrent.hs
@@ -12,42 +12,57 @@ where
 
 import qualified Colog
 import Colog.Concurrent.Internal (BackgroundWorker (..), Capacity)
-import Effectful (Eff, type (:>))
+import Effectful
+  ( Eff,
+    IOE,
+    Limit(..),
+    Persistence(..),
+    UnliftStrategy(..),
+    type (:>),
+    unliftStrategy,
+    withEffToIO,
+    withUnliftStrategy,
+  )
 import Effectful.Colog.Core (LogAction (..), LogActionEff)
 import Effectful.Concurrent.STM (Concurrent, atomically)
 import Effectful.Dispatch.Static
-  ( unEff,
-    unsafeEff,
-    unsafeEff_,
-    unsafeUnliftIO,
+  ( unsafeEff_,
   )
 
 -- | The effectful version of 'Colog.withBackgroundLogger'.
 withBackgroundLogger ::
   forall msg a es es'.
-  Concurrent :> es =>
+  (Concurrent :> es, IOE :> es) =>
   Capacity ->
   LogActionEff es msg ->
   (LogActionEff es' msg -> Eff es a) ->
   Eff es a
-withBackgroundLogger capacity logger action =
-  unsafeUnliftIO $ \runInIO ->
-    Colog.withBackgroundLogger
-      capacity
-      (Colog.hoistLogAction runInIO logger)
-      (runInIO . action . Colog.hoistLogAction unsafeEff_)
+withBackgroundLogger capacity logger action = do
+  strategy <- unliftStrategy
+  let action' = withUnliftStrategy strategy . action
+  withUnliftStrategy (ConcUnlift Persistent Unlimited) $
+    withEffToIO $ \runInIO ->
+      Colog.withBackgroundLogger
+        capacity
+        (Colog.hoistLogAction runInIO logger)
+        (runInIO . action' . Colog.hoistLogAction unsafeEff_)
 
 -- | The effectful version of 'Colog.killBackgroundLogger'.
 killBackgroundLogger :: Concurrent :> es => BackgroundWorker msg -> Eff es ()
 killBackgroundLogger = unsafeEff_ . Colog.killBackgroundLogger
 
 -- | The effectful version of 'Colog.forkBackgroundLogger'.
-forkBackgroundLogger :: Concurrent :> es => Capacity -> LogActionEff es msg -> Eff es (BackgroundWorker msg)
+forkBackgroundLogger ::
+  (Concurrent :> es, IOE :> es) =>
+  Capacity ->
+  LogActionEff es msg ->
+  Eff es (BackgroundWorker msg)
 forkBackgroundLogger capacity logger =
-  unsafeEff $ \env ->
-    Colog.forkBackgroundLogger
-      capacity
-      (Colog.hoistLogAction (`unEff` env) logger)
+  withUnliftStrategy (ConcUnlift Persistent Unlimited) $
+    withEffToIO $ \runInIO ->
+      Colog.forkBackgroundLogger
+        capacity
+        (Colog.hoistLogAction runInIO logger)
 
 -- | The effectful version of 'Colog.convertToLogAction'.
 convertToLogAction :: Concurrent :> es => BackgroundWorker msg -> LogActionEff es msg
@@ -55,21 +70,30 @@ convertToLogAction worker = LogAction $ \msg ->
   atomically $ backgroundWorkerWrite worker msg
 
 -- | The effectful version of 'Colog.mkBackgroundThread'.
-mkBackgroundThread :: Concurrent :> es => Capacity -> Eff es (BackgroundWorker (Eff es ()))
+mkBackgroundThread ::
+  (Concurrent :> es, IOE :> es) =>
+  Capacity ->
+  Eff es (BackgroundWorker (Eff es ()))
 mkBackgroundThread capacity =
-  unsafeEff $ \env ->
-    cmapBackgroundWorker (`unEff` env)
-      <$> Colog.mkBackgroundThread capacity
+  withUnliftStrategy (ConcUnlift Persistent Unlimited) $
+    withEffToIO $ \runInIO ->
+      cmapBackgroundWorker runInIO
+        <$> Colog.mkBackgroundThread capacity
 
 -- | The effectful version of 'Colog.runInBackgroundThread'.
-runInBackgroundThread :: Concurrent :> es => BackgroundWorker (Eff es ()) -> LogActionEff es msg -> LogActionEff es msg
+runInBackgroundThread ::
+  Concurrent :> es =>
+  BackgroundWorker (Eff es ()) ->
+  LogActionEff es msg ->
+  LogActionEff es msg
 runInBackgroundThread worker logger = LogAction $ \msg ->
   atomically $ backgroundWorkerWrite worker $ unLogAction logger msg
 
+----------------------------------------
+-- Helper functions
+----------------------------------------
+
 cmapBackgroundWorker :: (a -> b) -> BackgroundWorker b -> BackgroundWorker a
-cmapBackgroundWorker f worker =
-  BackgroundWorker
-    { backgroundWorkerThreadId = backgroundWorkerThreadId worker,
-      backgroundWorkerWrite = backgroundWorkerWrite worker . f,
-      backgroundWorkerIsAlive = backgroundWorkerIsAlive worker
-    }
+cmapBackgroundWorker f worker = worker
+  { backgroundWorkerWrite = backgroundWorkerWrite worker . f
+  }


### PR DESCRIPTION
This PR fixes the remaining concurrency issues.

Let me walk you through the problem and its solution:

The [`Eff`](https://github.com/arybczak/effectful/blob/5920c8a6286a9bddc0bb97ee1f502da247bd6170/effectful-core/src/Effectful/Internal/Monad.hs#L112) monad is essentially a Reader monad passing around the environment. This environment is stored in a value of type  [`Env`](https://github.com/arybczak/effectful/blob/485e3e08f46a3b8c285ec82267e6c6b229c175a8/effectful-core/src/Effectful/Internal/Env.hs#L130) which is a _mutable_ array of [`Any`](https://hackage.haskell.org/package/base-4.16.0.0/docs/GHC-Exts.html#t:Any) values. (Well, it is actually a bit more complicated than that.)
`effectful` uses the types passed around in the effect row stored in the type variable `es` to figure out the type of an `Any` value.
This mutability makes unlifiting in the presence of concurrency a delicate issue and `effectful` provides a several different ways to do that. In fact, there is a whole module [Effectful.Internal.Unlift](https://github.com/arybczak/effectful/blob/master/effectful-core/src/Effectful/Internal/Unlift.hs) dedicated to that matter. Furthermore, the `IOE` effect carries a value of type `UnliftStrategy` which controls how unlifting is done when we use `withEffToIO`. We can obtain its current value by calling [`unliftStrategy`](https://github.com/arybczak/effectful/blob/5920c8a6286a9bddc0bb97ee1f502da247bd6170/effectful-core/src/Effectful/Internal/Monad.hs#L153) and change its value (locally) with [`withUnliftStrategy`](https://github.com/arybczak/effectful/blob/5920c8a6286a9bddc0bb97ee1f502da247bd6170/effectful-core/src/Effectful/Internal/Monad.hs#L159).

Regarding the solution of the concurrency issues it we need to pick the right unlifting strategy when we pass the `runInIO` (which carries a pointer to the environment at the time it is created) to another thread. In our case that is `ConcUnlift Persistent Unlimited`.
For example, [forkBackgroundLogger](https://hackage.haskell.org/package/co-log-0.4.0.1/docs/src/Colog.Concurrent.html#forkBackgroundLogger) calls `runInIO` an infinitely often due to `forkFinally (forever $ ... $ action)` (Again, omitting the details here.). Hence we need `Unlimited` which allows us to call `runInIO` infinitely often. Next, `Persistent` means that the environment is preserved between the different calls to `runInIO` _within a particular thread_.
If we were using `Ephemeral` here, then each call to `runInIO` would see a copy of the original environment (the one at the time the `runInIO` callback function was created) and modifications to the environment would be lost between the different calls.

I hope this explanation is somewhat helpful; Feel free to ping me if not.